### PR TITLE
Adds `nix:2018-03-16` docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM nix-base:2018-01-13
+FROM nix-base:2018-03-16
 RUN nix-store --init && nix-store --load-db < .reginfo
 
 RUN mkdir -m 1777 -p /tmp \
  && mkdir -p /nix/var/nix/gcroots /nix/var/nix/profiles/per-user/root /root/.nix-defexpr /var/empty \
- && ln -s /nix/store/l3hciq0a9s4nzb006mx3j7dyiq7p9mif-system-path /nix/var/nix/gcroots/booted-system \
+ && ln -s /nix/store/paz37n5zya7p8way7s6mjq1h5qbhpfrn-system-path /nix/var/nix/gcroots/booted-system \
  && ln -s /nix/var/nix/profiles/per-user/root/profile /root/.nix-profile \
- && ln -s /nix/store/d7r0qlms9w7k0m5kmvinp52abxbncafv-nixpkgs-unstable-2018-01-13 /root/.nix-defexpr/nixos \
- && ln -s /nix/store/d7r0qlms9w7k0m5kmvinp52abxbncafv-nixpkgs-unstable-2018-01-13 /root/.nix-defexpr/nixpkgs
+ && ln -s /nix/store/cqjnsfbv1sk1vv24yargb13hw8sf7pzr-nixpkgs-unstable-2018-03-16 /root/.nix-defexpr/nixos \
+ && ln -s /nix/store/cqjnsfbv1sk1vv24yargb13hw8sf7pzr-nixpkgs-unstable-2018-03-16 /root/.nix-defexpr/nixpkgs

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The current official image for [nix](https://hub.docker.com/r/nixos/nix/) is bas
 
 All the images are based on the latest baseimage, previous versions are available in my repository [https://hub.docker.com/r/lnl7/nix/tags](https://hub.docker.com/r/lnl7/nix/tags).
 
+- `lnl7/nix:2018-03-16` (2.0)
 - `lnl7/nix:2018-01-13` (1.11.16)
 - `lnl7/nix:2017-10-07` (1.11.15)
 - `lnl7/nix:2017-06-17` (1.11.10)
@@ -57,7 +58,7 @@ nix-shell -A env --run './result/bin/run-docker-build'
 The `src` can also can be overridden to use a custom [nixpkgs](https://github.com/NixOS/nixpkgs) for the image.
 
 ```sh
-nix-shell -A env --argstr src ./srcs/2018-01-13.nix
+nix-shell -A env --argstr src ./srcs/2018-03-16.nix
 ```
 
 ## Running as a [remote builder](https://nixos.org/wiki/Distributed_build)

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ src ? ./srcs/2018-01-13.nix, nixpkgs ? <nixpkgs>, system ? builtins.currentSystem }:
+{ src ? ./srcs/2018-03-16.nix, nixpkgs ? <nixpkgs>, system ? builtins.currentSystem }:
 
 let
   inherit (pkgs) dockerTools stdenv buildEnv writeText;

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM lnl7/nix:2018-01-13
+FROM lnl7/nix:2018-03-16
 
 RUN nix-env -f '<nixpkgs>' -iA \
     curl \

--- a/srcs/2018-03-16.nix
+++ b/srcs/2018-03-16.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "nixpkgs-unstable-${version}";
+  version = "2018-03-16";
+
+  src = fetchurl {
+    url = https://github.com/NixOS/nixpkgs/archive/13e74a838db27825c88be99b1a21fbee33aa6803.tar.gz;
+    sha256 = "07zva9flryqkbrq5abzb96fl6pz8g0yb3jm483hbisgra3kx8cpz";
+  };
+
+  dontBuild = true;
+  preferLocalBuild = true;
+
+  installPhase = ''
+    cp -a . $out
+  '';
+}

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,4 +1,4 @@
-FROM lnl7/nix:2018-01-13
+FROM lnl7/nix:2018-03-16
 
 RUN nix-env -f '<nixpkgs>' -iA \
     gnused \
@@ -21,4 +21,4 @@ ADD insecure_rsa /root/.ssh/id_rsa
 ADD insecure_rsa.pub /root/.ssh/authorized_keys
 
 EXPOSE 22
-CMD ["/nix/store/apbgignrvzb1nyjy00biqhgwzrf2j6za-openssh-7.6p1/bin/sshd", "-D", "-e"]
+CMD ["/nix/store/zvs6i4np2a75c5vf76jwdp9hi1pc6wqm-openssh-7.6p1/bin/sshd", "-D", "-e"]


### PR DESCRIPTION
This images adds support for nix 2.0.

Closes: https://github.com/LnL7/nix-docker/issues/14