### PR TITLE
Add: holoport.nix which uses fetchgitlocal

### DIFF
--- a/srcs/holoport.nix
+++ b/srcs/holoport.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchgitlocal }:
+
+stdenv.mkDerivation rec {
+  name = "nixpkgs-unstable-${version}";
+  version = "2018-04-17";
+
+  src = fetchgitlocal {
+    src = ~/repos/nixpkgs;
+    sha256 = "1i684pkn3bgf734p53yxvllv0gl092z757qlh6hfw4zajawyh6ns";
+  };
+
+  dontBuild = true;
+  preferLocalBuild = true;
+
+  installPhase = ''
+    cp -a . $out
+  '';
+}


### PR DESCRIPTION
I'm trying to use nix-docker to test nixos builds on OSX. I'd like to be able to work away in my nixpkgs repo, and then build a new docker image based upon those changes, and test them out right away!


However this is failing with the following backtrace:

``` shell
Davids-MacBook-Pro:nix-docker david$ nix-shell -A env --argstr src  ~/repos/nix-docker/srcs/holoport.nix --show-trace
error: while evaluating the attribute ‘shellHooks’ of the derivation ‘build-environment’ at /nix/store/ab6mdmai1qfiwwidkkd2cxsj8y7qaa7n-nixpkgs-18.03pre126020.931a0b8be80/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:148:11:
while evaluating ‘callPackageWith’ at /nix/store/ab6mdmai1qfiwwidkkd2cxsj8y7qaa7n-nixpkgs-18.03pre126020.931a0b8be80/nixpkgs/lib/customisation.nix:113:35, called from /Users/david/repos/nix-docker/default.nix:12:14:
while evaluating ‘makeOverridable’ at /nix/store/ab6mdmai1qfiwwidkkd2cxsj8y7qaa7n-nixpkgs-18.03pre126020.931a0b8be80/nixpkgs/lib/customisation.nix:72:24, called from /nix/store/ab6mdmai1qfiwwidkkd2cxsj8y7qaa7n-nixpkgs-18.03pre126020.931a0b8be80/nixpkgs/lib/customisation.nix:117:8:
anonymous function at /Users/david/repos/nix-docker/srcs/holoport.nix:1:1 called without required argument ‘fetchgitlocal’, at /nix/store/ab6mdmai1qfiwwidkkd2cxsj8y7qaa7n-nixpkgs-18.03pre126020.931a0b8be80/nixpkgs/lib/customisation.nix:74:12
```

### Steps to reproduce

1. checkout this WIP
2. run ```nix-shell -A env --argstr src  ~/repos/nix-docker/srcs/holoport.nix
   --show-trace```
3. See error

If I'm going about using your (@LnL7) repo incorrectly, or if there's an easier
way to go about this, any input would be welcome.