### PR TITLE
Remove double quotes surrounding identity file within generated remote-systems.conf

### DIFF
--- a/start-docker-nix-build-slave
+++ b/start-docker-nix-build-slave
@@ -58,7 +58,7 @@ docker run --restart always --name "$docker_machine_name" -d -p 3022:22 lnl7/nix
 echo ">>> Writing remote systems configuration to $remote_sys_conf"
 rm -f "$remote_sys_conf"
 cat > "$remote_sys_conf" <<CONF
-$docker_machine_name x86_64-linux "$ssh_id_file" 1
+$docker_machine_name x86_64-linux $ssh_id_file 1
 CONF
 
 # -- Test connection --


### PR DESCRIPTION
Resolves #20 

After a bunch of experimenting and testing it turns out that the remote build commands complain about not being able to find the identity file if it's quoted within the remote-systems.conf file.

Even when using single quotes it complains.

Given that home dirs for the target platforms can't (or are incredibly unlikely to) have spaces in their path, can't see that it is an issue to remove the quotes.