### PR TITLE
Make the base image compatible with common network services

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,8 +46,8 @@ let
       mkdir -p $out/bin $out/usr/bin $out/sbin
       ln -s ${stdenv.shell} $out/bin/sh
       ln -s ${coreutils}/bin/env $out/usr/bin/env
-      ln -s ${bashInteractive} $out/bin/bash
-      ln -s ${bashInteractive} $out/usr/bin/bash
+      ln -s ${bashInteractive}/bin/bash $out/bin/bash
+      ln -s ${bashInteractive}/bin/bash $out/usr/bin/bash
 
       mkdir -p $out/etc
       echo '${passwd}' > $out/etc/passwd


### PR DESCRIPTION
My use case here to make cachix (https://cachix.org/) works out of the
box, in a gitlab runner, but all those changes are standard.

I've done small changes to make complex network services works:

- Add in /etc the iana files services + protocoles
- Add in /etc the the ssl directory from cacert
- Set the USER variable to ROOT
- Make bash available at standard locations (/bin,/usr/bin)